### PR TITLE
Exception validation fix

### DIFF
--- a/src/loader.py
+++ b/src/loader.py
@@ -11,8 +11,8 @@ class Loader:
             with open(self.file) as f:
                 f = json.load(f)
                 return f[key]
-        except Exception as e:
-            print(str(e))
         except KeyError:
             print("{} not found!".format(key))
+        except Exception as e:
+            print(str(e))
         


### PR DESCRIPTION
The Exception type takes every exception and by doing that ignores the KeyError exception.
How to fix: make the KeyError tyoe exception before the Exception type